### PR TITLE
Updated 'fluent-loggin' to 3.2.2 and transactionId returned in MDC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.ft.membership</groupId>
             <artifactId>fluent-logging</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/src/main/java/com/ft/api/util/transactionid/TransactionIdFilter.java
+++ b/src/main/java/com/ft/api/util/transactionid/TransactionIdFilter.java
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.MDC;
 
 import com.ft.membership.logging.Operation;
 
@@ -28,6 +29,7 @@ public class TransactionIdFilter implements Filter {
         HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
         httpServletResponse.setHeader(TransactionIdUtils.TRANSACTION_ID_HEADER, transactionId);
 
+        MDC.put("transaction_id", "transaction_id=" + transactionId);
 		final Operation operationJson = operation("doFilter").jsonLayout()
 			.initiate(this);
         
@@ -42,6 +44,7 @@ public class TransactionIdFilter implements Filter {
 
 			operationJson.logIntermediate()
 				.yielding("msg", "REQUEST HANDLED")
+				.yielding("systemcode", "jaxrs-transaction-id-handling")
 				.yielding("transaction_id", transactionId)
 				.yielding("responsetime", timeTakenMillis)
 				.yielding("protocol", httpServletRequest.getProtocol())
@@ -55,7 +58,7 @@ public class TransactionIdFilter implements Filter {
 				.yielding("userAgent", httpServletRequest.getRemoteUser())
 				.yielding("exception_was_thrown", !success)
 				.logInfo();
-
+			MDC.remove("transaction_id");
 		}
 	}
 


### PR DESCRIPTION
- Returned 'transaction-id' setting again with MDC (needed currently in many services)
- Updated 'fluent-logging' lib to 3.2.2
